### PR TITLE
Add multi-source MFR support with graph-aware iteration cap

### DIFF
--- a/mfrpy/sgmfr.py
+++ b/mfrpy/sgmfr.py
@@ -6,21 +6,42 @@ from igraph import Graph
 from mfrpy import update_expand
 from sympy.logic.boolalg import to_dnf
 
-def get_mfrs(graph, source, target, expanded = False, verbose = False, mode = "es"):
+
+def _default_max_iterations(graph, num_sources):
+    """Graph-aware iteration cap for the bottom-up MFR search.
+
+    Node count alone is too small: branching partial MFRs can grow much
+    faster than |V|, especially with cycles and multiple sources. Scale
+    with both |V| and |E|, and with the number of source nodes.
     """
-    Given a graph, source node, and target node, returns the number of MFRs
-    from source to target and all MFRs.
+    n = graph.vcount()
+    m = graph.ecount()
+    k = max(1, num_sources)
+    return max(n * n * k, m * n, n * 100)
+
+
+def get_mfrs(graph, source, target, expanded = False, verbose = False, mode = "es", max_iterations = None):
+    """
+    Given a graph, one or more source nodes, and a target node, returns all
+    minimal functional routes (MFRs) from the source set to the target, and
+    their count.
 
     Uses *python-igraph*:
     http://igraph.org/python/
 
     Parameters:
     graph  -- *igraph* Graph object
-    source -- array of integer indices of source node
+    source -- integer index or list of integer indices of source node(s).
+              Multiple sources are supported: each MFR may terminate at any
+              node in `source`. Synergistic (AND) combinations are expressed
+              via composite nodes in the expanded graph.
     target -- integer index of target node
     expanded -- if the input graph is already expanded
     verbose -- option to display MFRs, defaults to False
     mode -- output option, defaults to "es"
+    max_iterations -- safety cap on the main loop to guarantee termination
+                      on pathological graphs. If None (default), a cap is
+                      derived from graph size and source count.
 
     Supported output options:
     "em" -- returns edge matrices
@@ -28,6 +49,12 @@ def get_mfrs(graph, source, target, expanded = False, verbose = False, mode = "e
     "es" -- returns edge sequence indices
 
     """
+
+    # Normalize source: accept a single int as well as a list/tuple/set
+    if isinstance(source, int):
+        source = [source]
+    else:
+        source = list(source)
 
     # Extract attributes from graph if they exist
     oggraph = graph
@@ -47,6 +74,10 @@ def get_mfrs(graph, source, target, expanded = False, verbose = False, mode = "e
             graph,
             update_expand.updates(graph, synergistic, negatory)
             )
+
+    if max_iterations is None:
+        max_iterations = _default_max_iterations(graph, len(source))
+
     # Initialization of variables for main loop
     pointer = 0
     num = 1
@@ -69,7 +100,18 @@ def get_mfrs(graph, source, target, expanded = False, verbose = False, mode = "e
         print("nodes with no predecessors (other than source):", redundant, graph.vs[redundant]["name"])
 
     # Main loop, while some partial MFRs remain unfinished
+    iterations = 0
     while pointer < num:
+        iterations += 1
+        if iterations > max_iterations:
+            raise RuntimeError(
+                "MFR search exceeded iteration cap ({}) for graph with "
+                "{} nodes and {} edges; partial results are not returned. "
+                "Increase max_iterations or inspect the graph for "
+                "pathological cycles.".format(
+                    max_iterations, graph.vcount(), graph.ecount()
+                )
+            )
         flag = False
         c_MFR = all_MFRs[pointer]
         c_tag = tags[pointer]
@@ -147,6 +189,16 @@ def get_mfrs(graph, source, target, expanded = False, verbose = False, mode = "e
                 # Appends new rows to current partial MFR
                 else:
                     for v in c_preds:
+                        # Cycle / multi-source guard: if v is already a "from"
+                        # node in the current MFR (i.e. already in `stems`),
+                        # do not append it again. Without this, graphs with
+                        # cycles -- amplified by multiple sources -- keep
+                        # adding duplicate rows and the main loop never
+                        # terminates (this is the dendritic ex-dendritic.py
+                        # multi-input infinite loop).
+                        if v in stems:
+                            continue
+
                         temp2 = net[v]
 
                         if verbose:

--- a/mfrpy/test/test_mfr_processing.py
+++ b/mfrpy/test/test_mfr_processing.py
@@ -180,6 +180,123 @@ class TestMfrEdgeCases(unittest.TestCase):
             self.fail(f"Should handle complex synergy pattern: {e}")
 
 
+class TestMultiSource(unittest.TestCase):
+    """Multi-input source tests for get_mfrs.
+
+    These tests cover the scenarios that previously infinite-looped, such as
+    the first 9 lines of sandbox/ex-dendritic.py (multiple sources reaching
+    a target through a cyclic, partially synergistic graph).
+    """
+
+    @unittest.skipUnless(HAS_IGRAPH and HAS_MFRPY, "Requires igraph and mfrpy")
+    def test_multi_source_int_or_list(self):
+        """Source argument should accept both an int and a list."""
+        g = Graph(directed=True)
+        g.add_vertices(3)
+        g.add_edges([(0, 1), (1, 2)])
+        g.vs["name"] = ["A", "B", "C"]
+        g.es["synergy"] = [0, 0]
+        r_int = sgmfr.get_mfrs(g, 0, 2, mode="es", verbose=False)
+        r_list = sgmfr.get_mfrs(g, [0], 2, mode="es", verbose=False)
+        self.assertEqual(r_int[1], r_list[1])
+
+    @unittest.skipUnless(HAS_IGRAPH and HAS_MFRPY, "Requires igraph and mfrpy")
+    def test_multi_source_two_disjoint_paths(self):
+        """Two sources, two disjoint paths to one target -> 2 MFRs."""
+        g = Graph(directed=True)
+        g.add_vertices(5)
+        g.add_edges([(0, 2), (1, 3), (2, 4), (3, 4)])
+        g.vs["name"] = ["s1", "s2", "a", "b", "t"]
+        g.es["synergy"] = [0, 0, 0, 0]
+        result = sgmfr.get_mfrs(g, [0, 1], 4, mode="es", verbose=False)
+        mfrs, count = result
+        self.assertGreaterEqual(count, 2,
+            "Two disjoint source-to-target paths should produce >=2 MFRs")
+
+    @unittest.skipUnless(HAS_IGRAPH and HAS_MFRPY, "Requires igraph and mfrpy")
+    def test_multi_source_with_synergy_and(self):
+        """Two sources synergistically required (AND) at the target.
+
+        Mirrors ex-2source.py: i1, i2 -> a/b -> c/o where the target
+        depends on a synergy of two upstream paths.
+        """
+        g = Graph(directed=True)
+        g.add_vertices(6)
+        g.add_edges([(0, 2), (1, 3), (1, 2), (3, 2), (3, 4), (3, 5), (2, 4), (4, 5)])
+        g.vs["name"] = ["i1", "i2", "a", "b", "c", "o"]
+        g.es["synergy"] = [1, 0, 1, 0, 0, 0, 0, 0]
+        result = sgmfr.get_mfrs(g, [0, 1], 5, mode="es", verbose=False)
+        self.assertIsNotNone(result)
+        mfrs, count = result
+        self.assertIsInstance(mfrs, list)
+        self.assertIsInstance(count, int)
+
+    @unittest.skipUnless(HAS_IGRAPH and HAS_MFRPY, "Requires igraph and mfrpy")
+    def test_multi_source_with_cycle_terminates(self):
+        """Multi-source on a cyclic graph must terminate (no infinite loop).
+
+        Reproduces the structural shape of the dendritic example: two source
+        nodes, a downstream cycle, and a single target. Before the fix this
+        would spin forever; the iteration cap + cycle-safe pred handling
+        ensure it terminates.
+        """
+        g = Graph(directed=True)
+        g.add_vertices(6)
+        g.add_edges([
+            (0, 2), (1, 2),
+            (2, 3), (3, 4), (4, 2),
+            (3, 5),
+        ])
+        g.vs["name"] = ["s1", "s2", "x", "y", "z", "t"]
+        g.es["synergy"] = [0, 0, 0, 0, 0, 0]
+        result = sgmfr.get_mfrs(
+            g, [0, 1], 5, mode="es", verbose=False, max_iterations=10000
+        )
+        self.assertIsNotNone(result, "Should terminate even with cycles")
+        mfrs, count = result
+        self.assertIsInstance(mfrs, list)
+        self.assertIsInstance(count, int)
+
+    @unittest.skipUnless(HAS_IGRAPH and HAS_MFRPY, "Requires igraph and mfrpy")
+    def test_multi_source_only_one_reaches(self):
+        """If only one source has a path to target, MFRs should still be
+        found and the unreachable source must not break the run."""
+        g = Graph(directed=True)
+        g.add_vertices(4)
+        g.add_edges([(0, 2), (2, 3)])
+        g.vs["name"] = ["s_reach", "s_isolated", "x", "t"]
+        g.es["synergy"] = [0, 0]
+        result = sgmfr.get_mfrs(g, [0, 1], 3, mode="es", verbose=False)
+        self.assertIsNotNone(result)
+        mfrs, count = result
+        self.assertGreaterEqual(count, 1)
+
+    @unittest.skipUnless(HAS_IGRAPH and HAS_MFRPY, "Requires igraph and mfrpy")
+    def test_iteration_cap_raises_without_partial_results(self):
+        """Hitting max_iterations should raise, not return partial MFRs."""
+        g = Graph(directed=True)
+        g.add_vertices(3)
+        g.add_edges([(0, 1), (1, 2)])
+        g.vs["name"] = ["A", "B", "C"]
+        g.es["synergy"] = [0, 0]
+        with self.assertRaises(RuntimeError) as ctx:
+            sgmfr.get_mfrs(g, [0], 2, mode="es", verbose=False, max_iterations=0)
+        self.assertIn("iteration cap", str(ctx.exception).lower())
+
+    @unittest.skipUnless(HAS_IGRAPH and HAS_MFRPY, "Requires igraph and mfrpy")
+    def test_default_iteration_cap_completes(self):
+        """Default graph-aware cap (max_iterations=None) should finish small graphs."""
+        g = Graph(directed=True)
+        g.add_vertices(5)
+        g.add_edges([(0, 2), (1, 3), (2, 4), (3, 4)])
+        g.vs["name"] = ["s1", "s2", "a", "b", "t"]
+        g.es["synergy"] = [0, 0, 0, 0]
+        result = sgmfr.get_mfrs(g, [0, 1], 4, mode="es", verbose=False)
+        self.assertIsNotNone(result)
+        mfrs, count = result
+        self.assertGreaterEqual(count, 1)
+
+
 class TestMfrIntegration(unittest.TestCase):
     """Integration tests for full MFR workflow"""
     


### PR DESCRIPTION
## Summary

This PR adds support for multiple input source nodes in `sgmfr.get_mfrs` and
fixes the infinite loop seen in `sandbox/ex-dendritic.py` when calling
`get_mfrs(dendrite, [32, 36], 29)`.

## Changes

- Accept `source` as either a single int or a list of source indices
- Skip predecessors already present in the current partial MFR (fixes cycle +
  multi-source infinite loop)
- Add graph-aware default `max_iterations` when not explicitly provided:
  `max(n^2 * num_sources, m * n, n * 100)`
- Raise `RuntimeError` if the iteration cap is hit (no partial results returned)

## Tests

Added multi-source unit tests in `mfrpy/test/test_mfr_processing.py`.
Full suite: 43/43 passing locally.

## Manual checks (sandbox toys)

- `sandbox/ex-dendritic.py` multi-source call: terminates (~3.1s), 16945 MFRs
- `sandbox/ex-2source.py`: terminates, 5 MFRs
- `sandbox/ex-loop.py` (3 synergy settings): all terminate, 1 MFR each

## Notes on termination

"Termination" here means the algorithm completes normally without hitting
`max_iterations` and without raising another error. If the cap is hit, the
function raises `RuntimeError` and does not return partial MFR output.